### PR TITLE
added more extension + fixed regex for include statement

### DIFF
--- a/codeviz.py
+++ b/codeviz.py
@@ -7,8 +7,8 @@ import re
 import glob
 
 
-SOURCE_EXTENSIONS = ('.c', '.cpp')
-HEADER_EXTENSIONS = ('.h', '.hpp')
+SOURCE_EXTENSIONS = ('.c', '.cpp', '.cc', '.c++', '.cxx', '.C')
+HEADER_EXTENSIONS = ('.h', '.hpp', '.hcc', '.hh', '.h++', '.hxx', '.H')
 EXTENSIONS = SOURCE_EXTENSIONS + HEADER_EXTENSIONS
 
 

--- a/codeviz.py
+++ b/codeviz.py
@@ -47,7 +47,7 @@ class File():
         self.included_headers = self._get_included_headers()
 
     def _get_included_headers(self):
-        includes_re = re.compile(r'\s*#\s*include\s+["<](?P<file>.+?)[">]')
+        includes_re = re.compile(r'\s*#\s*include\s*["<](?P<file>.+?)[">]')
 
         with open(self.path, 'rt') as f:
             data = f.read()

--- a/codeviz.py
+++ b/codeviz.py
@@ -8,7 +8,7 @@ import glob
 
 
 SOURCE_EXTENSIONS = ('.c', '.cpp', '.cc', '.c++', '.cxx', '.C')
-HEADER_EXTENSIONS = ('.h', '.hpp', '.hcc', '.hh', '.h++', '.hxx', '.H')
+HEADER_EXTENSIONS = ('.h', '.hpp', '.hcc', '.tcc', '.hh', '.h++', '.hxx', '.H')
 EXTENSIONS = SOURCE_EXTENSIONS + HEADER_EXTENSIONS
 
 


### PR DESCRIPTION
I added more c++ extensions that can be found. I personnally always use .cc and .hh (they are really used, it's not only me)

I also fixed the regex for inlusion statement to allow for no space between "#include" and the quoted filename (I personnaly hate useless space, but that's syntactically ok anyway)